### PR TITLE
Fix README to show IE instead of EI

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -19,7 +19,7 @@ Each legal opcode (00-FF and CB 00 - CB FF) has a .json file. Each .json file re
     "h": 98,
     "l": 251,
     "ime": 0,
-    "ei": 0,
+    "ie": 0,
     "ram": [
       [
         16826,
@@ -43,7 +43,7 @@ Each legal opcode (00-FF and CB 00 - CB FF) has a .json file. Each .json file re
     "pc": 16827,
     "sp": 9383,
     "ime": 0,
-    "ei": 0,
+    "ie": 0,
     "ram": [
       [
         16826,


### PR DESCRIPTION
I was working on implementing support for these tests in my Game Boy emulator when I noticed that the README erroneously shows EI instead of IE. (See also #1)

It's a minor fix but it will save time and confusion for those who are referencing the README while parsing the JSON.